### PR TITLE
Fix Django 5.0+ compatibility in FakeJoinField.get_extra_restriction

### DIFF
--- a/judge/utils/raw_sql.py
+++ b/judge/utils/raw_sql.py
@@ -25,7 +25,12 @@ class FakeJoinField:
     def get_joining_columns(self):
         return self.joining_columns
 
-    def get_extra_restriction(self, where_class, alias, related_alias, remote_alias=None):
+    def get_extra_restriction(self, *args, **kwargs):
+        """
+        Compatible with both Django < 5.0 and Django >= 5.0
+        Django < 5.0: get_extra_restriction(self, where_class, alias, related_alias)
+        Django >= 5.0: get_extra_restriction(self, alias, related_alias)
+        """
         pass
 
 


### PR DESCRIPTION
- Changed method signature from (self, where_class, alias, related_alias, remote_alias=None) to (self, *args, **kwargs)
- Django 5.0+ changed get_extra_restriction signature from 3 params to 2 params (removed where_class)
- Using *args/**kwargs makes it compatible with both Django < 5.0 and Django >= 5.0
- Added docstring explaining the compatibility change


