### PR TITLE
fix: rollback Django to 5.1 and django-compressor to 4.4 for compatib…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-# Django 5.2 compatible packages
-Django>=5.2,<5.3
+# Django 5.1 compatible packages
+Django>=5.1,<5.2
 
-# Django extensions - all compatible with Django 5.2
+# Django extensions - all compatible with Django 5.1
 django-cleanup>=8.1.0
-django_compressor>=4.5.1
-django-mptt>=0.18.0  # Supports Django 5.2
+django_compressor>=4.4,<4.5
+django-mptt>=0.18.0  # Supports Django 5.1
 django-registration-redux>=2.13
 django-reversion>=6.0.0  # Latest version with Django 5.x support
 django-social-share>=2.3.0


### PR DESCRIPTION


- Downgrade Django from 5.2 to 5.1 due to breaking changes
- Downgrade django-compressor from 4.5.1 to 4.4 to fix CSS compression issues
- Django 5.2 removed get_storage_class() causing ImportError in compressor
- This fixes CSS loading errors on problem pages after Django upgrade


