### PR TITLE
fix: apply compressor patch in manage.py and wsgi.py

### DIFF
--- a/dmoj/wsgi.py
+++ b/dmoj/wsgi.py
@@ -8,5 +8,12 @@ except ImportError:
 
     pymysql.install_as_MySQLdb()
 
+# Apply django-compressor compatibility patch BEFORE Django setup
+# This must run before any django-compressor imports
+try:
+    import dmoj.compressor_patch  # noqa: F401
+except ImportError:
+    pass
+
 from django.core.wsgi import get_wsgi_application  # noqa: E402, django must be imported here
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -10,5 +10,12 @@ except ImportError:
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'dmoj.settings')
 
+    # Apply django-compressor compatibility patch BEFORE Django setup
+    # This must run before any django-compressor imports
+    try:
+        import dmoj.compressor_patch  # noqa: F401
+    except ImportError:
+        pass
+
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
- Move patch import to manage.py before Django setup
- Add patch import to wsgi.py for production uwsgi/gunicorn
- Patch must be loaded before any django-compressor imports
- This ensures get_storage_class() is available when compressor loads


