### PR TITLE
chore: update martor dependency to use Django 5.1 compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ dmoj-wpadmin @ git+https://github.com/DMOJ/dmoj-wpadmin.git
 django-fernet-fields @ git+https://github.com/DMOJ/django-fernet-fields.git
 jsonfield @ git+https://github.com/DMOJ/jsonfield.git
 ansi2html @ git+https://github.com/DMOJ/ansi2html.git
-martor @ git+https://github.com/VNOI-Admin/martor.git
+martor @ git+https://github.com/phancddev/martor.git
 markdown2 @ git+https://github.com/qhhoj/python-markdown2.git
 
 # Syntax highlighting and text processing


### PR DESCRIPTION
- Switch martor source from VNOI-Admin to phancddev repository
- New version includes Django 5.1 compatibility fixes
- Replaces deprecated Django APIs (ugettext_lazy, is_ajax, force_text)


