### PR TITLE
fix: prevent ValueError when creating new contest in admin

### DIFF
--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -121,7 +121,11 @@ class ContestForm(ModelForm):
 
     def clean(self):
         cleaned_data = super(ContestForm, self).clean()
-        cleaned_data['banned_users'].filter(current_contest__contest=self.instance).update(current_contest=None)
+        # Only update current_contest if the instance has been saved (has an id)
+        # When creating a new contest, self.instance.id is None, so we skip this
+        if self.instance and self.instance.id:
+            cleaned_data['banned_users'].filter(current_contest__contest=self.instance).update(current_contest=None)
+        return cleaned_data
 
     class Meta:
         widgets = {


### PR DESCRIPTION
- Add check for instance.id before filtering banned_users
- Fix 'Model instances passed to related filters must be saved' error
- Only update current_contest for existing contests, not new ones
- Add return statement to clean() method following Django best practices

