### PR TITLE
fix: replace Django date filter with Python strftime/isoformat in Jin…

### DIFF
--- a/templates/admin/user_activity/all_logs.html
+++ b/templates/admin/user_activity/all_logs.html
@@ -110,7 +110,7 @@
                     <tbody>
                         {% for activity in activities %}
                         <tr>
-                            <td>{{ activity.timestamp|date:"Y-m-d H:i:s" }}</td>
+                            <td>{{ activity.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
                             <td>
                                 {% if activity.user %}
                                     <a href="/admin/user-activity/user/{{ activity.user.username }}/">

--- a/templates/admin/user_activity/user_detail.html
+++ b/templates/admin/user_activity/user_detail.html
@@ -150,7 +150,7 @@
                                 {% for activity in activities %}
                                 <tr>
                                     <td>
-                                        <small>{{ activity.timestamp|date:"Y-m-d H:i:s" }}</small>
+                                        <small>{{ activity.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</small>
                                     </td>
                                     <td>
                                         <code>{{ activity.path|truncatechars:50 }}</code>
@@ -247,7 +247,7 @@
                                     <td>{{ session.browser }}</td>
                                     <td>{{ session.os }}</td>
                                     <td>{{ session.last_activity|timesince }} ago</td>
-                                    <td>{{ session.created_at|date:"Y-m-d H:i" }}</td>
+                                    <td>{{ session.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
@@ -290,7 +290,7 @@
                                     <td>{{ session.browser }}</td>
                                     <td>{{ session.os }}</td>
                                     <td>{{ session.last_activity|timesince }} ago</td>
-                                    <td>{{ session.created_at|date:"Y-m-d H:i" }}</td>
+                                    <td>{{ session.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
                                     <td>
                                         {% if session.is_active %}
                                             <span class="badge bg-success">Active</span>
@@ -337,7 +337,7 @@
                                         </span>
                                     </td>
                                     <td>{{ session.last_activity|timesince }} ago</td>
-                                    <td>{{ session.created_at|date:"m-d H:i" }}</td>
+                                    <td>{{ session.created_at.strftime('%m-%d %H:%M') }}</td>
                                     <td>
                                         {% if session.is_active %}
                                             <span class="badge bg-success">Active</span>

--- a/templates/admin/user_activity/user_detail_standalone.html
+++ b/templates/admin/user_activity/user_detail_standalone.html
@@ -305,7 +305,7 @@
                                     {% for activity in activities %}
                                     <tr>
                                         <td>
-                                            <small>{{ activity.timestamp|date:"m-d H:i:s" }}</small>
+                                            <small>{{ activity.timestamp.strftime('%m-%d %H:%M:%S') }}</small>
                                         </td>
                                         <td>
                                             <code style="font-size: 0.8em;">
@@ -416,7 +416,7 @@
                                         <td>{{ session.os|truncatechars:20 }}</td>
                                         <td>
                                             <script>
-                                                document.write(new Date('{{ session.last_activity|date:"c" }}').toLocaleString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                                document.write(new Date('{{ session.last_activity.isoformat() }}').toLocaleString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                             </script>
                                         </td>
                                         <td>

--- a/templates/user_activity/active_users.html
+++ b/templates/user_activity/active_users.html
@@ -561,12 +561,12 @@
                                 <div class="status-badge status-active">
                                     <i class="fa fa-circle"></i>
                                     <script>
-                                        document.write(new Date('{{ session.last_activity|date:"c" }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity.isoformat() }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                     </script>
                                 </div>
                                 <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                     <script>
-                                        document.write(new Date('{{ session.last_activity|date:"c" }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity.isoformat() }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
                                     </script>
                                 </div>
                             {% else %}
@@ -634,12 +634,12 @@
                                 <div class="status-badge status-active">
                                     <i class="fa fa-circle"></i>
                                     <script>
-                                        document.write(new Date('{{ session.last_activity|date:"c" }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity.isoformat() }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                     </script>
                                 </div>
                                 <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                     <script>
-                                        document.write(new Date('{{ session.last_activity|date:"c" }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity.isoformat() }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
                                     </script>
                                 </div>
                             {% else %}
@@ -698,12 +698,12 @@
                                 <div class="status-badge status-active">
                                     <i class="fa fa-circle"></i>
                                     <script>
-                                        document.write(new Date('{{ session.last_activity|date:"c" }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity.isoformat() }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                     </script>
                                 </div>
                                 <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                     <script>
-                                        document.write(new Date('{{ session.last_activity|date:"c" }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity.isoformat() }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
                                     </script>
                                 </div>
                             {% else %}


### PR DESCRIPTION
…ja2 templates

- Replace |date:"c" with .isoformat() for ISO 8601 format
- Replace |date:"Y-m-d H:i:s" with .strftime('%Y-%m-%d %H:%M:%S')
- Replace |date:"m-d H:i" with .strftime('%m-%d %H:%M')
- Fixes TemplateSyntaxError: expected token 'end of print statement', got ':'
- Django's date filter syntax is incompatible with Jinja2 template engine
- Affects user_activity templates: active_users.html, user_detail.html, user_detail_standalone.html, all_logs.html

