### PR TITLE
fix: use correct Jinja2 filter syntax for date formatting

### DIFF
--- a/templates/admin/user_activity/all_logs.html
+++ b/templates/admin/user_activity/all_logs.html
@@ -110,7 +110,7 @@
                     <tbody>
                         {% for activity in activities %}
                         <tr>
-                            <td>{{ date(activity.timestamp, "Y-m-d H:i:s") }}</td>
+                            <td>{{ activity.timestamp|date("Y-m-d H:i:s") }}</td>
                             <td>
                                 {% if activity.user %}
                                     <a href="/admin/user-activity/user/{{ activity.user.username }}/">

--- a/templates/admin/user_activity/user_detail.html
+++ b/templates/admin/user_activity/user_detail.html
@@ -150,7 +150,7 @@
                                 {% for activity in activities %}
                                 <tr>
                                     <td>
-                                        <small>{{ date(activity.timestamp, "Y-m-d H:i:s") }}</small>
+                                        <small>{{ activity.timestamp|date("Y-m-d H:i:s") }}</small>
                                     </td>
                                     <td>
                                         <code>{{ activity.path|truncatechars:50 }}</code>
@@ -247,7 +247,7 @@
                                     <td>{{ session.browser }}</td>
                                     <td>{{ session.os }}</td>
                                     <td>{{ session.last_activity|timesince }} ago</td>
-                                    <td>{{ date(session.created_at, "Y-m-d H:i") }}</td>
+                                    <td>{{ session.created_at|date("Y-m-d H:i") }}</td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
@@ -290,7 +290,7 @@
                                     <td>{{ session.browser }}</td>
                                     <td>{{ session.os }}</td>
                                     <td>{{ session.last_activity|timesince }} ago</td>
-                                    <td>{{ date(session.created_at, "Y-m-d H:i") }}</td>
+                                    <td>{{ session.created_at|date("Y-m-d H:i") }}</td>
                                     <td>
                                         {% if session.is_active %}
                                             <span class="badge bg-success">Active</span>
@@ -337,7 +337,7 @@
                                         </span>
                                     </td>
                                     <td>{{ session.last_activity|timesince }} ago</td>
-                                    <td>{{ date(session.created_at, "m-d H:i") }}</td>
+                                    <td>{{ session.created_at|date("m-d H:i") }}</td>
                                     <td>
                                         {% if session.is_active %}
                                             <span class="badge bg-success">Active</span>

--- a/templates/admin/user_activity/user_detail_standalone.html
+++ b/templates/admin/user_activity/user_detail_standalone.html
@@ -305,7 +305,7 @@
                                     {% for activity in activities %}
                                     <tr>
                                         <td>
-                                            <small>{{ date(activity.timestamp, "m-d H:i:s") }}</small>
+                                            <small>{{ activity.timestamp|date("m-d H:i:s") }}</small>
                                         </td>
                                         <td>
                                             <code style="font-size: 0.8em;">
@@ -416,7 +416,7 @@
                                         <td>{{ session.os|truncatechars:20 }}</td>
                                         <td>
                                             <script>
-                                                document.write(new Date('{{ date(session.last_activity, "c") }}').toLocaleString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                                document.write(new Date('{{ session.last_activity|date("c") }}').toLocaleString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                             </script>
                                         </td>
                                         <td>

--- a/templates/user_activity/active_users.html
+++ b/templates/user_activity/active_users.html
@@ -561,12 +561,12 @@
                                 <div class="status-badge status-active">
                                     <i class="fa fa-circle"></i>
                                     <script>
-                                        document.write(new Date('{{ date(session.last_activity, "c") }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity|date("c") }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                     </script>
                                 </div>
                                 <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                     <script>
-                                        document.write(new Date('{{ date(session.last_activity, "c") }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity|date("c") }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
                                     </script>
                                 </div>
                             {% else %}
@@ -634,12 +634,12 @@
                                 <div class="status-badge status-active">
                                     <i class="fa fa-circle"></i>
                                     <script>
-                                        document.write(new Date('{{ date(session.last_activity, "c") }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity|date("c") }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                     </script>
                                 </div>
                                 <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                     <script>
-                                        document.write(new Date('{{ date(session.last_activity, "c") }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity|date("c") }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
                                     </script>
                                 </div>
                             {% else %}
@@ -698,12 +698,12 @@
                                 <div class="status-badge status-active">
                                     <i class="fa fa-circle"></i>
                                     <script>
-                                        document.write(new Date('{{ date(session.last_activity, "c") }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity|date("c") }}').toLocaleTimeString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', hour: '2-digit', minute: '2-digit', second: '2-digit'}));
                                     </script>
                                 </div>
                                 <div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">
                                     <script>
-                                        document.write(new Date('{{ date(session.last_activity, "c") }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
+                                        document.write(new Date('{{ session.last_activity|date("c") }}').toLocaleDateString('vi-VN', {timeZone: 'Asia/Ho_Chi_Minh', year: 'numeric', month: '2-digit', day: '2-digit'}));
                                     </script>
                                 </div>
                             {% else %}


### PR DESCRIPTION
- Change date(value, "format") to value|date("format")
- date is registered as a filter, not a function in Jinja2
- Fixes UndefinedError: 'date' is undefined
- Filter syntax: {{ value|filter_name(args) }}
- Function syntax: {{ function_name(value, args) }}
- Affects all user_activity templates

