### PR TITLE
fix: migrate from pytz to zoneinfo for Django 5.2 compatibility

### DIFF
--- a/judge/models/choices.py
+++ b/judge/models/choices.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
 from operator import itemgetter
+import zoneinfo
 
-import pytz
 from django.utils.translation import gettext_lazy as _
 
 
 def make_timezones():
     data = defaultdict(list)
-    for tz in pytz.all_timezones:
+    for tz in zoneinfo.available_timezones():
         if '/' in tz:
             area, loc = tz.split('/', 1)
         else:

--- a/judge/tasks/webhook.py
+++ b/judge/tasks/webhook.py
@@ -1,4 +1,5 @@
-import pytz
+import zoneinfo
+
 from celery import shared_task
 from discord_webhook import (
     DiscordEmbed,
@@ -178,7 +179,7 @@ def on_new_contest(contest_key):
     url = settings.SITE_FULL_URL + contest.get_absolute_url()
     title = f'New contest {url}'
 
-    tz = pytz.timezone(settings.DEFAULT_USER_TIME_ZONE)
+    tz = zoneinfo.ZoneInfo(settings.DEFAULT_USER_TIME_ZONE)
 
     description = [
         ('Title', contest.name),

--- a/judge/timezone.py
+++ b/judge/timezone.py
@@ -1,4 +1,5 @@
-import pytz
+import zoneinfo
+
 from django.conf import settings
 from django.db import connection
 from django.utils import timezone
@@ -16,7 +17,7 @@ class TimezoneMiddleware(object):
         tzname = settings.DEFAULT_USER_TIME_ZONE
         if request.profile:
             tzname = request.profile.timezone
-        return pytz.timezone(tzname)
+        return zoneinfo.ZoneInfo(tzname)
 
     def __call__(self, request):
         with timezone.override(self.get_timezone(request)):

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import os
+import zoneinfo
 from datetime import (
     datetime,
     timedelta,
@@ -11,7 +12,6 @@ from operator import (
     itemgetter,
 )
 
-import pytz
 from django.conf import settings
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.decorators import login_required
@@ -296,7 +296,7 @@ class UserAboutPage(UserPage):
         user_timezone = settings.DEFAULT_USER_TIME_ZONE
         if self.request is not None and self.request.profile is not None:
             user_timezone = user_timezone or self.request.profile.timezone
-        timezone_offset = pytz.timezone(user_timezone).utcoffset(datetime.utcnow()).seconds
+        timezone_offset = zoneinfo.ZoneInfo(user_timezone).utcoffset(datetime.now(dt_timezone.utc)).seconds
 
         submissions = (
             self.object.submission_set


### PR DESCRIPTION
fix: migrate from pytz to zoneinfo for Django 5.2 compatibility

- Replace pytz with zoneinfo in TimezoneMiddleware to fix datetime conversion issues
- Update timezone handling in user views, webhook tasks, and timezone choices
- Fix random datetime offset errors (e.g., 7 or 18 minutes) when setting contest times
- Align with Django 4.0+ default timezone implementation (zoneinfo)
- Remove deprecated pytz usage as it will be removed in Django 5.0

This fixes the issue where contest start/end times would randomly shift when saved,
caused by incompatibility between pytz and zoneinfo timezone objects.