### PR TITLE
fix: apply django-compressor compatibility patch in Celery entry point

### DIFF
--- a/dmoj_celery.py
+++ b/dmoj_celery.py
@@ -8,5 +8,12 @@ except ImportError:
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'dmoj.settings')
 
+# Apply django-compressor compatibility patch BEFORE Django setup
+# This must run before any django-compressor imports
+try:
+    import dmoj.compressor_patch  # noqa: F401, imported for side effect
+except ImportError:
+    pass
+
 # noinspection PyUnresolvedReferences
 from dmoj.celery import app  # noqa: E402, F401, imported for side effect


### PR DESCRIPTION
update