### PR TITLE
test: drop redundant HTTP_HOST override in public ranking tests

### DIFF
--- a/judge/models/tests/test_public_ranking_link.py
+++ b/judge/models/tests/test_public_ranking_link.py
@@ -26,10 +26,6 @@ class PublicRankingLinkTestCase(CommonDataMixin, TestCase):
         )
         cls.outsider = create_user(username='public_ranking_outsider')
 
-    def setUp(self):
-        super().setUp()
-        self.client.defaults['HTTP_HOST'] = 'localhost'
-
     def make_contest(self, key, **kwargs):
         defaults = {
             'authors': (self.manager.username,),


### PR DESCRIPTION
test: drop redundant HTTP_HOST override in public ranking tests